### PR TITLE
new: Additional version tokens

### DIFF
--- a/tools/internal-schema/CHANGELOG.md
+++ b/tools/internal-schema/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added new version tokens: `{versionMinor}`, `{versionPatch}`, `{versionMonth}`, `{versionDay}`, and deprecated `{versionMajorMinor}` and `{versionYearMonth}`.
+
 ## 0.16.3
 
 #### 🚀 Updates

--- a/tools/internal-schema/Cargo.toml
+++ b/tools/internal-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "schema_tool"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/tools/internal-schema/src/proto.rs
+++ b/tools/internal-schema/src/proto.rs
@@ -230,6 +230,9 @@ fn interpolate_tokens(
         let major = v.major.to_string();
         let minor = v.minor.to_string();
         let patch = v.patch.to_string();
+        let year = format!("{:0>4}", v.major);
+        let month = format!("{:0>2}", v.minor);
+        let day = format!("{:0>2}", v.patch);
         let major_minor = format!("{}.{}", v.major, v.minor); // Deprecated, remains for backwards compatibility
         let year_month = format!("{:0>4}-{:0>2}", v.major, v.minor); // Deprecated, remains for backwards compatibility
         let pre = v.pre.to_string();
@@ -240,9 +243,9 @@ fn interpolate_tokens(
             .replace("{versionMinor}", &minor)
             .replace("{versionPatch}", &patch)
             .replace("{versionMajorMinor}", &major_minor) // Deprecated, remains for backwards compatibility
-            .replace("{versionYear}", &major)
-            .replace("{versionMonth}", &minor)
-            .replace("{versionDay}", &patch)
+            .replace("{versionYear}", &year)
+            .replace("{versionMonth}", &month)
+            .replace("{versionDay}", &day)
             .replace("{versionYearMonth}", &year_month) // Deprecated, remains for backwards compatibility
             .replace("{versionPrerelease}", &pre)
             .replace("{versionBuild}", &build);

--- a/tools/internal-schema/src/proto.rs
+++ b/tools/internal-schema/src/proto.rs
@@ -228,24 +228,34 @@ fn interpolate_tokens(
 
     if let Some(v) = version.as_version() {
         let major = v.major.to_string();
-        let major_minor = format!("{}.{}", v.major, v.minor);
-        let year_month = format!("{:0>4}-{:0>2}", v.major, v.minor);
+        let minor = v.minor.to_string();
+        let patch = v.patch.to_string();
+        let major_minor = format!("{}.{}", v.major, v.minor); // Deprecated, remains for backwards compatibility
+        let year_month = format!("{:0>4}-{:0>2}", v.major, v.minor); // Deprecated, remains for backwards compatibility
         let pre = v.pre.to_string();
         let build = v.build.to_string();
 
         value = value
             .replace("{versionMajor}", &major)
-            .replace("{versionMajorMinor}", &major_minor)
+            .replace("{versionMinor}", &minor)
+            .replace("{versionPatch}", &patch)
+            .replace("{versionMajorMinor}", &major_minor) // Deprecated, remains for backwards compatibility
             .replace("{versionYear}", &major)
-            .replace("{versionYearMonth}", &year_month)
+            .replace("{versionMonth}", &minor)
+            .replace("{versionDay}", &patch)
+            .replace("{versionYearMonth}", &year_month) // Deprecated, remains for backwards compatibility
             .replace("{versionPrerelease}", &pre)
             .replace("{versionBuild}", &build);
     } else {
         value = value
             .replace("{versionMajor}", "")
-            .replace("{versionMajorMinor}", "")
+            .replace("{versionMinor}", "")
+            .replace("{versionPatch}", "")
+            .replace("{versionMajorMinor}", "") // Deprecated, remains for backwards compatibility
             .replace("{versionYear}", "")
-            .replace("{versionYearMonth}", "")
+            .replace("{versionMonth}", "")
+            .replace("{versionDay}", "")
+            .replace("{versionYearMonth}", "") // Deprecated, remains for backwards compatibility
             .replace("{versionPrerelease}", "")
             .replace("{versionBuild}", "");
     }


### PR DESCRIPTION
See moonrepo/proto#711

Adds `{versionMinor}`, `{versionPatch}`, `{versionMonth}` and` {versionDay}` tokens to allow more fine grained control when building the download-url for some edge cases.

`{versionMajorMinor}` and `{versionYearMonth}` are deprecated (which will be reflected in documentation) as these can now be built manually i.e. as `{versionMajor}.{versionMinor}`. This makes them redundant, but they remain for backwards compatibility to keep this a non-breaking change.

*I have assumed this will be released as `0.16.4` when bumping the version - if not then this will affect moonrepo/proto#712*