### PR TITLE
Add irb to ruby tool

### DIFF
--- a/tools/ruby/src/proto.rs
+++ b/tools/ruby/src/proto.rs
@@ -144,6 +144,10 @@ pub fn locate_executables(
                 "bundle".into(),
                 ExecutableConfig::new(env.os.get_exe_name("bin/bundle")),
             ),
+            (
+                "irb".into(),
+                ExecutableConfig::new(env.os.get_exe_name("bin/irb")),
+            ),
         ]),
         exes_dirs: vec!["bin".into()],
         globals_lookup_dirs: vec![],


### PR DESCRIPTION
Add support for `irb` to the Ruby tool.

Issue: #93 
Related PR: https://github.com/moonrepo/proto/pull/897
