### PR TITLE
fix: (rust) Ignore Cargo.toml self-dependencies

### DIFF
--- a/toolchains/rust/src/tier2.rs
+++ b/toolchains/rust/src/tier2.rs
@@ -40,8 +40,11 @@ pub fn extend_project_graph(
                     };
 
                     // Only inherit if the dependency is using the local `path = "..."` syntax,
-                    // and the package name exists in our gathered map
-                    if dep.detail().is_some_and(|det| det.path.is_some()) {
+                    // is not a self-dependency and the package name exists in our gathered map
+                    if dep
+                        .detail()
+                        .is_some_and(|det| det.path.as_ref().is_some_and(|path| path != "."))
+                    {
                         project_output.dependencies.push(ProjectDependency {
                             id: dep_id.to_owned(),
                             scope,

--- a/toolchains/rust/tests/__fixtures__/projects/c/Cargo.toml
+++ b/toolchains/rust/tests/__fixtures__/projects/c/Cargo.toml
@@ -7,3 +7,4 @@ a = { path = "../a" }
 
 [dev-dependencies]
 b = { path = "../b" }
+c = { path = "." }


### PR DESCRIPTION
With moon 2.x, it seems that projects can no longer have cycles. This is an issue for Rust crates using self-dependencies (`path = "."`) - a very old ugly hack to activate features during tests (https://github.com/rust-lang/cargo/issues/2911).

This PR makes it so such dependencies are ignored during graph extension, as they don't really add anything except causing cycles.

Could probably be done globally for all plugins inside `moon` itself, but I think this quirk is pretty much Rust exclusive.