### PR TITLE
fix: normalize python distribution names

### DIFF
--- a/toolchains/python/src/pyproject_toml.rs
+++ b/toolchains/python/src/pyproject_toml.rs
@@ -57,6 +57,26 @@ impl std::ops::DerefMut for PyProjectTomlInner {
     }
 }
 
+// Python distribution names are compared using the normalized form from PEP 503.
+pub fn normalize_distribution_name(name: &str) -> String {
+    let mut normalized = String::with_capacity(name.len());
+    let mut last_was_separator = false;
+
+    for ch in name.chars() {
+        if matches!(ch, '-' | '_' | '.') {
+            if !last_was_separator {
+                normalized.push('-');
+                last_was_separator = true;
+            }
+        } else {
+            normalized.push(ch.to_ascii_lowercase());
+            last_was_separator = false;
+        }
+    }
+
+    normalized
+}
+
 // Workspace support: https://docs.astral.sh/uv/concepts/projects/workspaces/
 // Only define fields we need!
 

--- a/toolchains/python/src/tier2.rs
+++ b/toolchains/python/src/tier2.rs
@@ -1,6 +1,6 @@
 use crate::config::*;
 use crate::managers::*;
-use crate::pyproject_toml::{PyProjectToml, PyProjectTomlWithTools};
+use crate::pyproject_toml::{PyProjectToml, PyProjectTomlWithTools, normalize_distribution_name};
 use extism_pdk::*;
 use moon_config::DependencyScope;
 use moon_pdk::{
@@ -18,7 +18,7 @@ pub fn extend_project_graph(
 ) -> FnResult<Json<ExtendProjectGraphOutput>> {
     let mut output = ExtendProjectGraphOutput::default();
 
-    // First pass, gather all packages and their manifests
+    // First pass, gather all packages and their manifests.
     let mut packages = BTreeMap::default();
 
     for (id, source) in input.project_sources {
@@ -40,7 +40,7 @@ pub fn extend_project_graph(
                 project.keywords = None;
                 project.classifiers = None;
 
-                packages.insert(project.name.clone(), (id, manifest));
+                packages.insert(normalize_distribution_name(&project.name), (id, manifest));
             }
         }
     }
@@ -52,7 +52,8 @@ pub fn extend_project_graph(
         let mut extract_implicit_deps =
             |reqs: &[Requirement], scope: DependencyScope| -> AnyResult<()> {
                 for req in reqs {
-                    let req_name = req.name.to_string();
+                    let req_label = req.name.as_ref().to_owned();
+                    let req_name = normalize_distribution_name(req.name.as_ref());
 
                     if req.extras.is_empty()
                         && req.version_or_url.is_none()
@@ -62,7 +63,7 @@ pub fn extend_project_graph(
                         project_output.dependencies.push(ProjectDependency {
                             id: dep_id.to_owned(),
                             scope,
-                            via: Some(format!("requirement {req_name}")),
+                            via: Some(format!("requirement {req_label}")),
                         });
                     }
                 }

--- a/toolchains/python/tests/tier2_test.rs
+++ b/toolchains/python/tests/tier2_test.rs
@@ -75,6 +75,51 @@ mod python_toolchain_tier2 {
         }
 
         #[tokio::test(flavor = "multi_thread")]
+        async fn resolves_requirements_against_normalized_manifest_name() {
+            let sandbox = create_empty_moon_sandbox();
+            sandbox.create_file(
+                "backend_service/pyproject.toml",
+                r#"[project]
+name = "internal_lib"
+version = "1.0.0"
+"#,
+            );
+            sandbox.create_file(
+                "consumer/pyproject.toml",
+                r#"[project]
+name = "consumer"
+version = "1.0.0"
+dependencies = ["internal-lib"]
+"#,
+            );
+
+            let plugin = sandbox.create_toolchain("python").await;
+
+            let mut input = ExtendProjectGraphInput::default();
+            input
+                .project_sources
+                .insert(Id::raw("backend-service"), "backend_service".into());
+            input
+                .project_sources
+                .insert(Id::raw("consumer"), "consumer".into());
+
+            let output = plugin.extend_project_graph(input).await;
+
+            assert_eq!(
+                output
+                    .extended_projects
+                    .get("consumer")
+                    .unwrap()
+                    .dependencies,
+                vec![ProjectDependency {
+                    id: Id::raw("backend-service"),
+                    scope: DependencyScope::Production,
+                    via: Some("requirement internal-lib".into()),
+                }]
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
         async fn ignores_projects_not_in_sources() {
             let sandbox = create_moon_sandbox("projects");
             let plugin = sandbox.create_toolchain("python").await;


### PR DESCRIPTION
Normalize Python project names to support PEP 503-equivalent names like `internal_lib` and `internal-lib`.

@milesj Thanks for all the effort put into moonrepo! Looking into adapting it for @ElevenLabs, and this is the remaining blocker.