### PR TITLE
fix(javascript): handle pnpm v10 multi-document lockfiles

### DIFF
--- a/toolchains/javascript/CHANGELOG.md
+++ b/toolchains/javascript/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Fixed `pnpm-lock.yaml` parsing for pnpm v10's multi-document lockfiles, which
+  are written when `managePackageManagerVersions` is enabled (the default).
+
 ## 1.0.7
 
 #### 🚀 Updates

--- a/toolchains/javascript/src/lockfiles/pnpm.rs
+++ b/toolchains/javascript/src/lockfiles/pnpm.rs
@@ -9,9 +9,18 @@ use starbase_utils::{fs, yaml};
 
 pub fn parse_pnpm_lock_yaml(path: &VirtualPath, output: &mut ParseLockOutput) -> AnyResult<()> {
     let content = fs::read_file(path)?;
-    let lock: PnpmLock = yaml::parse(&content)?;
 
-    for (name, package) in lock.packages {
+    // pnpm v10 with `managePackageManagerVersions` writes a multi-document
+    // pnpm-lock.yaml — the package-manager metadata in one document and the
+    // project lockfile in another, separated by `---` markers. Merge packages
+    // from every document so we don't fail on `more than one document`.
+    let mut packages = FxHashMap::default();
+    for doc in yaml::serde_yaml::Deserializer::from_str(&content) {
+        let lock = PnpmLock::deserialize(doc)?;
+        packages.extend(lock.packages);
+    }
+
+    for (name, package) in packages {
         let (name, version) = parse_name_and_version(&name);
         let reso = package.resolution;
 

--- a/toolchains/javascript/tests/__fixtures__/lockfiles/pnpm-multidoc/pnpm-lock.yaml
+++ b/toolchains/javascript/tests/__fixtures__/lockfiles/pnpm-multidoc/pnpm-lock.yaml
@@ -1,0 +1,48 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 10.33.0
+        version: 10.33.0
+
+packages:
+
+  pnpm@10.33.0:
+    resolution: {integrity: sha512-pmhash==}
+    engines: {node: '>=18.12'}
+    hasBin: true
+
+snapshots:
+
+  pnpm@10.33.0: {}
+
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.2
+
+packages:
+
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.9.2: {}

--- a/toolchains/javascript/tests/tier2_test.rs
+++ b/toolchains/javascript/tests/tier2_test.rs
@@ -2040,6 +2040,47 @@ mod javascript_toolchain_tier2 {
             assert_eq!(output.dependencies, expected_base_dependencies());
         }
 
+        // pnpm v10 with `managePackageManagerVersions` writes a multi-document
+        // pnpm-lock.yaml (separated by `---`) — one document for the package
+        // manager metadata, one for the project lockfile.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn parses_pnpm_multidoc() {
+            let sandbox = create_lockfile_sandbox("pnpm-multidoc");
+            let plugin = sandbox.create_toolchain("javascript").await;
+
+            let output = plugin
+                .parse_lock(ParseLockInput {
+                    path: VirtualPath::Real(sandbox.path().join("pnpm-lock.yaml")),
+                    ..Default::default()
+                })
+                .await;
+
+            assert_eq!(
+                output.dependencies,
+                BTreeMap::from_iter([
+                    (
+                        "pnpm".into(),
+                        vec![LockDependency {
+                            hash: Some("sha512-pmhash==".into()),
+                            version: Some(VersionSpec::parse("10.33.0").unwrap()),
+                            ..Default::default()
+                        }],
+                    ),
+                    (
+                        "typescript".into(),
+                        vec![LockDependency {
+                            hash: Some(
+                                "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="
+                                    .into()
+                            ),
+                            version: Some(VersionSpec::parse("5.9.2").unwrap()),
+                            ..Default::default()
+                        }],
+                    ),
+                ])
+            );
+        }
+
         #[tokio::test(flavor = "multi_thread")]
         async fn parses_yarn() {
             let sandbox = create_lockfile_sandbox("yarn");


### PR DESCRIPTION
## Problem

pnpm v10 with [`managePackageManagerVersions`](https://pnpm.io/settings#managepackagemanagerversions) enabled (the default) writes `pnpm-lock.yaml` as a **multi-document YAML** — one document for the package-manager metadata, a second for the project lockfile, separated by `---` markers.

This commonly triggers when [`pnpm/action-setup@v6`](https://github.com/pnpm/action-setup) is used in CI: v6 installs pnpm into `~/setup-pnpm/node_modules/`, pnpm v10 detects itself in `PNPM_HOME` and rewrites the lockfile with a `packageManagerDependencies` block in its own document.

The current parser uses `starbase_utils::yaml::parse` which calls `serde_norway::from_str` — that doesn't accept multi-document input. Result: every `moon run` aborts before any task executes:

```
Error: plugin::wasm::failed_function_call

  × Failed to parse YAML.
  │
  │ Caused by:
  │     deserializing from YAML containing more than one document is not supported
```

The lockfile produced by pnpm looks like:

```yaml
---
lockfileVersion: '9.0'
importers:
  .:
    packageManagerDependencies:
      pnpm:
        specifier: 10.33.0
        version: 10.33.0
packages:
  pnpm@10.33.0: { resolution: { integrity: ... } }
snapshots:
  pnpm@10.33.0: {}
---
lockfileVersion: '9.0'
settings:
  autoInstallPeers: true
importers:
  .:
    devDependencies:
      typescript: { specifier: ^5.9.0, version: 5.9.2 }
packages:
  typescript@5.9.2: { resolution: { integrity: ... } }
snapshots:
  typescript@5.9.2: {}
```

## Fix

Switch from `yaml::parse` to `serde_norway::Deserializer::from_str`, which iterates over every document, and merge `packages` from each one. `serde_norway` is already pulled in transitively via `starbase_utils::yaml`.

Before:

```rust
let lock: PnpmLock = yaml::parse(&content)?;
for (name, package) in lock.packages { ... }
```

After:

```rust
let mut packages = FxHashMap::default();
for doc in yaml::serde_yaml::Deserializer::from_str(&content) {
    let lock = PnpmLock::deserialize(doc)?;
    packages.extend(lock.packages);
}
for (name, package) in packages { ... }
```

The diff is +13/-2 lines in `pnpm.rs`, plus a new fixture and test. Single-document lockfiles still work because `Deserializer::from_str` yields one item for them.

## Test plan

- [x] Added a `pnpm-multidoc` fixture that mirrors the lockfile shape pnpm v10 actually writes
- [x] Added `parses_pnpm_multidoc` in `tier2_test.rs` asserting both documents' packages end up in `output.dependencies`
- [x] Existing `parses_pnpm` (single-document) test still passes — `Deserializer::from_str` handles single-doc YAML transparently
- [x] Verified end-to-end against a real broken lockfile from a CI failure: built `cargo build --target wasm32-wasip1 --release`, pointed `toolchains.yml` at the local `.wasm`, ran `moon run`. Without the patch: same `more than one document` error. With the patch: parses cleanly and tasks execute.

Notes:

- Did not filter the pnpm/`@pnpm/exe` entries out of `output.dependencies`. They're harmless — moon will track changes to them like any other dep — and filtering would be a behaviour change beyond the scope of this fix. Happy to add if preferred.
- ~~I couldn't run `cargo nextest run` locally because of an unrelated `proto_core 0.55.4` compile error in the test build (`missing field 'working_dir' in initializer of PluginContext`). Not introduced by this PR; CI will be the source of truth.~~

Refs:
- [pnpm/action-setup#198](https://github.com/pnpm/action-setup/pull/198) (the v6 install layout change that surfaces this).
- [pnpm/pnpm#10964](https://github.com/pnpm/pnpm/pull/10964) (PNPM change that added multi-doc YAML)