### PR TITLE
fix: update to gomod-parser 0.5.1

### DIFF
--- a/.protolock
+++ b/.protolock
@@ -48,6 +48,13 @@ version = "10.0.0"
 checksum = "sha256:550078a66a3bb1065bae29f047b25210fbc966b69d3d2a6aab74d0378e37916a"
 
 [[tools.proto]]
+os = "macos"
+arch = "arm64"
+spec = "0.56.4"
+version = "0.56.4"
+checksum = "sha256:28ac2b3fb905aa692496eaf6f507c5cd79454b28d2e039c984677a3bd40a47bc"
+
+[[tools.proto]]
 os = "windows"
 arch = "x64"
 spec = "0.56.4"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,7 +1943,7 @@ version = "1.2.0"
 dependencies = [
  "extism-pdk",
  "go_tool",
- "gomod-parser2",
+ "gomod-parser",
  "moon_common",
  "moon_config",
  "moon_pdk",
@@ -1959,12 +1959,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "gomod-parser2"
-version = "0.4.2"
+name = "gomod-parser"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc233fbc11d750f71a45d4721fc73b545a60bb1ef1452d692c542de657d39c6"
+checksum = "45499f1bb8073c7a3912a60ff0d17b68a8a905d53e59e9332b3e253055e6008c"
 dependencies = [
- "winnow 0.7.15",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -7243,9 +7243,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/toolchains/go/Cargo.toml
+++ b/toolchains/go/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["cdylib", "lib"]
 toolchain_common = { path = "../../crates/toolchain-common" }
 go_tool = { path = "../../tools/go", default-features = false }
 extism-pdk = { workspace = true }
-gomod-parser2 = "0.4.2"
+gomod-parser = "0.5.1"
 moon_config = { workspace = true }
 moon_pdk = { workspace = true, features = ["schematic"] }
 moon_pdk_api = { workspace = true }

--- a/toolchains/go/src/go_mod.rs
+++ b/toolchains/go/src/go_mod.rs
@@ -4,7 +4,7 @@ use go_tool::version::from_go_version;
 use moon_pdk_api::{AnyResult, anyhow};
 use std::str::FromStr;
 
-pub use gomod_parser2::*;
+pub use gomod_parser::*;
 
 pub fn parse_go_mod(content: impl AsRef<str>) -> AnyResult<GoMod> {
     let mut go_mod = GoMod::from_str(content.as_ref()).map_err(|error| anyhow!("{error}"))?;

--- a/toolchains/go/src/go_work.rs
+++ b/toolchains/go/src/go_work.rs
@@ -23,6 +23,7 @@ impl GoWork {
         let mut work = Self::default();
         let mut in_use_block = false;
         let mut in_replace_block = false;
+        let mut in_ignore_block = false;
 
         for mut line in content.as_ref().lines() {
             if line.starts_with("//") {
@@ -37,16 +38,20 @@ impl GoWork {
                 continue;
             }
 
-            // use (), replace ()
+            // use (), replace (), ignore ()
             if line.starts_with("use (") {
                 in_use_block = true;
             } else if line.starts_with("replace (") {
                 in_replace_block = true;
+            } else if line.starts_with("ignore (") {
+                in_ignore_block = true;
             } else if line.trim() == ")" {
                 if in_use_block {
                     in_use_block = false;
                 } else if in_replace_block {
                     in_replace_block = false;
+                } else if in_ignore_block {
+                    in_ignore_block = false;
                 }
             }
 
@@ -59,6 +64,11 @@ impl GoWork {
             // replace <path>
             if !in_replace_block && line.starts_with("replace ") {
                 // Ignore for now!
+                continue;
+            }
+
+            // ignore <path>
+            if !in_ignore_block && line.starts_with("ignore ") {
                 continue;
             }
 

--- a/toolchains/go/tests/__fixtures__/mod-files/advanced.mod
+++ b/toolchains/go/tests/__fixtures__/mod-files/advanced.mod
@@ -17,3 +17,10 @@ exclude example.com/old/thing v1.2.3
 replace example.com/bad/thing v1.4.5 => example.com/good/thing v1.4.5
 
 retract [v1.9.0, v1.9.5]
+
+ignore ./node_modules
+
+ignore (
+	./dist
+	./build
+)

--- a/toolchains/go/tests/__fixtures__/work-files/advanced.work
+++ b/toolchains/go/tests/__fixtures__/work-files/advanced.work
@@ -21,3 +21,10 @@ replace (
 )
 
 use f
+
+ignore ./node_modules
+
+ignore (
+	./dist
+	./build
+)

--- a/toolchains/go/tests/go_mod_test.rs
+++ b/toolchains/go/tests/go_mod_test.rs
@@ -98,4 +98,28 @@ mod go_mod {
         )
         .unwrap();
     }
+
+    #[test]
+    fn parses_with_ignore_directive() {
+        let content = r#"
+module github.com/org/repo
+
+go 1.24.0
+
+ignore ./node_modules
+
+ignore (
+	./dist
+	./build
+)
+
+require example.com/thing v1.2.3
+"#;
+
+        let go_mod = parse_go_mod(content).unwrap();
+
+        assert_eq!(go_mod.module, "github.com/org/repo");
+        assert_eq!(go_mod.go.unwrap(), "1.24.0");
+        assert_eq!(go_mod.require.len(), 1);
+    }
 }

--- a/toolchains/go/tests/go_work_test.rs
+++ b/toolchains/go/tests/go_work_test.rs
@@ -49,4 +49,27 @@ mod go_work {
         )
         .unwrap();
     }
+
+    #[test]
+    fn parses_with_ignore_directive() {
+        let content = r#"
+go 1.24.0
+
+use ./a
+
+ignore ./node_modules
+
+ignore (
+	./dist
+	./build
+)
+
+use ./b
+"#;
+
+        let go_work = GoWork::parse(content).unwrap();
+
+        assert_eq!(go_work.version.unwrap(), "1.24.0");
+        assert_eq!(go_work.modules, vec!["a", "b"]);
+    }
 }


### PR DESCRIPTION
Adds support for Go 1.24's new `ignore` directive in both `go.mod` and `go.work` files. The main changes ensure that the parser can handle and ignore these directives