### PR TITLE
new: Support platform-scoped arch and libc overrides in TOML schemas

### DIFF
--- a/tools/internal-schema/CHANGELOG.md
+++ b/tools/internal-schema/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added `[platform.*.arch]` and `[platform.*.libc]` tables for platform-scoped `{arch}`/`{libc}` token overrides. Resolution order: platform map → global `[install.arch]`/`[install.libc]` → raw value. Identity overrides (mapping a value to itself) shadow the global map.
+
 ## 0.17.8
 
 #### 🚀 Updates

--- a/tools/internal-schema/src/proto.rs
+++ b/tools/internal-schema/src/proto.rs
@@ -207,6 +207,7 @@ fn interpolate_tokens(
     value: &str,
     version: &VersionSpec,
     schema: &Schema,
+    platform: &PlatformMapper,
     env: &HostEnvironment,
 ) -> String {
     let arch = env.arch.to_rust_arch();
@@ -216,7 +217,11 @@ fn interpolate_tokens(
         .replace("{version}", &version.to_string())
         .replace(
             "{arch}",
-            schema.install.arch.get(&env.arch).unwrap_or(&arch),
+            platform
+                .arch
+                .get(&env.arch)
+                .or_else(|| schema.install.arch.get(&env.arch))
+                .unwrap_or(&arch),
         )
         .replace("{os}", &os);
 
@@ -226,7 +231,11 @@ fn interpolate_tokens(
 
         value = value.replace(
             "{libc}",
-            schema.install.libc.get(&env.libc).unwrap_or(&libc),
+            platform
+                .libc
+                .get(&env.libc)
+                .or_else(|| schema.install.libc.get(&env.libc))
+                .unwrap_or(&libc),
         );
     }
 
@@ -289,7 +298,8 @@ pub fn download_prebuilt(
     let version = &input.context.version;
     let is_canary = version.is_canary();
 
-    let download_file = interpolate_tokens(&platform.download_file, version, &schema, &env);
+    let download_file =
+        interpolate_tokens(&platform.download_file, version, &schema, platform, &env);
 
     let download_url = interpolate_tokens(
         if is_canary {
@@ -303,6 +313,7 @@ pub fn download_prebuilt(
         },
         version,
         &schema,
+        platform,
         &env,
     )
     .replace("{download_file}", &download_file);
@@ -311,6 +322,7 @@ pub fn download_prebuilt(
         platform.checksum_file.as_deref().unwrap_or("CHECKSUM.txt"),
         version,
         &schema,
+        platform,
         &env,
     );
 
@@ -325,13 +337,14 @@ pub fn download_prebuilt(
     };
 
     let checksum_url = checksum_url.map(|url| {
-        interpolate_tokens(url, version, &schema, &env).replace("{checksum_file}", &checksum_file)
+        interpolate_tokens(url, version, &schema, platform, &env)
+            .replace("{checksum_file}", &checksum_file)
     });
 
     let archive_prefix = platform
         .archive_prefix
         .as_ref()
-        .map(|prefix| interpolate_tokens(prefix, version, &schema, &env));
+        .map(|prefix| interpolate_tokens(prefix, version, &schema, platform, &env));
 
     Ok(Json(DownloadPrebuiltOutput {
         archive_prefix,
@@ -400,6 +413,7 @@ pub fn locate_executables(
                 exe_path.to_str().unwrap_or("<invalidpath>"),
                 &input.context.version,
                 &schema,
+                platform,
                 &env,
             )
             .into(),

--- a/tools/internal-schema/src/schema.rs
+++ b/tools/internal-schema/src/schema.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct PlatformMapper {
+    pub arch: HashMap<HostArch, String>,
     pub archs: Vec<HostArch>,
     pub archive_prefix: Option<String>,
     pub checksum_file: Option<String>,
@@ -14,6 +15,7 @@ pub struct PlatformMapper {
     pub exes_dir: Option<PathBuf>,
     pub exes_dirs: Vec<PathBuf>,
     pub exe_path: Option<PathBuf>,
+    pub libc: HashMap<HostLibc, String>,
     #[deprecated]
     pub bin_path: Option<PathBuf>,
 }

--- a/tools/internal-schema/tests/__fixtures__/schemas/arch-overrides.toml
+++ b/tools/internal-schema/tests/__fixtures__/schemas/arch-overrides.toml
@@ -15,6 +15,7 @@ download-url = "https://example.com/v{version}/{download_file}"
 
 [install.arch]
 aarch64 = "arm64"
+x86_64 = "amd64"
 
 [resolve]
 git-url = "https://github.com/example/tool"

--- a/tools/internal-schema/tests/__fixtures__/schemas/arch-overrides.toml
+++ b/tools/internal-schema/tests/__fixtures__/schemas/arch-overrides.toml
@@ -1,0 +1,20 @@
+name = "arch-override-test"
+type = "cli"
+
+[platform.linux]
+download-file = "tool-Linux-{arch}"
+
+[platform.linux.arch]
+aarch64 = "aarch64"
+
+[platform.macos]
+download-file = "tool-Darwin-{arch}"
+
+[install]
+download-url = "https://example.com/v{version}/{download_file}"
+
+[install.arch]
+aarch64 = "arm64"
+
+[resolve]
+git-url = "https://github.com/example/tool"

--- a/tools/internal-schema/tests/__fixtures__/schemas/libc-overrides.toml
+++ b/tools/internal-schema/tests/__fixtures__/schemas/libc-overrides.toml
@@ -1,0 +1,14 @@
+name = "libc-override-test"
+type = "cli"
+
+[platform.linux]
+download-file = "tool-{arch}-unknown-linux-{libc}"
+
+[platform.linux.libc]
+gnu = "musl"
+
+[install]
+download-url = "https://example.com/v{version}/{download_file}"
+
+[resolve]
+git-url = "https://github.com/example/tool"

--- a/tools/internal-schema/tests/download_test.rs
+++ b/tools/internal-schema/tests/download_test.rs
@@ -456,8 +456,10 @@ mod schema_tool {
             );
         }
 
+        // A platform arch table that exists but lacks the host's key must fall
+        // through to the global map per-key, not disable it wholesale.
         #[tokio::test(flavor = "multi_thread")]
-        async fn unmapped_arch_passes_through_raw() {
+        async fn global_fallback_when_platform_map_lacks_key() {
             let sandbox = create_empty_proto_sandbox();
             let plugin = sandbox
                 .create_schema_plugin_with_config(
@@ -479,10 +481,10 @@ mod schema_tool {
                 })
                 .await;
 
-            assert_eq!(output.download_name.unwrap(), "tool-Linux-x86_64");
+            assert_eq!(output.download_name.unwrap(), "tool-Linux-amd64");
             assert_eq!(
                 output.download_url,
-                "https://example.com/v1.0.0/tool-Linux-x86_64"
+                "https://example.com/v1.0.0/tool-Linux-amd64"
             );
         }
 

--- a/tools/internal-schema/tests/download_test.rs
+++ b/tools/internal-schema/tests/download_test.rs
@@ -391,6 +391,135 @@ mod schema_tool {
         }
     }
 
+    mod platform_overrides {
+        use super::*;
+
+        // An identity override (platform value equals the raw arch) must still
+        // shadow the global remap, not be treated as absent.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn platform_identity_override_beats_global_remap() {
+            let sandbox = create_empty_proto_sandbox();
+            let plugin = sandbox
+                .create_schema_plugin_with_config(
+                    "arch-override-test",
+                    locate_fixture("schemas").join("arch-overrides.toml"),
+                    |config| {
+                        config.host(HostOS::Linux, HostArch::Arm64);
+                    },
+                )
+                .await;
+
+            let output = plugin
+                .download_prebuilt(DownloadPrebuiltInput {
+                    context: PluginContext {
+                        version: VersionSpec::parse("1.0.0").unwrap(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .await;
+
+            assert_eq!(output.download_name.unwrap(), "tool-Linux-aarch64");
+            assert_eq!(
+                output.download_url,
+                "https://example.com/v1.0.0/tool-Linux-aarch64"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn global_remap_applies_when_platform_has_no_override() {
+            let sandbox = create_empty_proto_sandbox();
+            let plugin = sandbox
+                .create_schema_plugin_with_config(
+                    "arch-override-test",
+                    locate_fixture("schemas").join("arch-overrides.toml"),
+                    |config| {
+                        config.host(HostOS::MacOS, HostArch::Arm64);
+                    },
+                )
+                .await;
+
+            let output = plugin
+                .download_prebuilt(DownloadPrebuiltInput {
+                    context: PluginContext {
+                        version: VersionSpec::parse("1.0.0").unwrap(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .await;
+
+            assert_eq!(output.download_name.unwrap(), "tool-Darwin-arm64");
+            assert_eq!(
+                output.download_url,
+                "https://example.com/v1.0.0/tool-Darwin-arm64"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn unmapped_arch_passes_through_raw() {
+            let sandbox = create_empty_proto_sandbox();
+            let plugin = sandbox
+                .create_schema_plugin_with_config(
+                    "arch-override-test",
+                    locate_fixture("schemas").join("arch-overrides.toml"),
+                    |config| {
+                        config.host(HostOS::Linux, HostArch::X64);
+                    },
+                )
+                .await;
+
+            let output = plugin
+                .download_prebuilt(DownloadPrebuiltInput {
+                    context: PluginContext {
+                        version: VersionSpec::parse("1.0.0").unwrap(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .await;
+
+            assert_eq!(output.download_name.unwrap(), "tool-Linux-x86_64");
+            assert_eq!(
+                output.download_url,
+                "https://example.com/v1.0.0/tool-Linux-x86_64"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn platform_libc_override_beats_detected_libc() {
+            let sandbox = create_empty_proto_sandbox();
+            let plugin = sandbox
+                .create_schema_plugin_with_config(
+                    "libc-override-test",
+                    locate_fixture("schemas").join("libc-overrides.toml"),
+                    |config| {
+                        config.host(HostOS::Linux, HostArch::X64);
+                    },
+                )
+                .await;
+
+            let output = plugin
+                .download_prebuilt(DownloadPrebuiltInput {
+                    context: PluginContext {
+                        version: VersionSpec::parse("1.0.0").unwrap(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .await;
+
+            assert_eq!(
+                output.download_name.unwrap(),
+                "tool-x86_64-unknown-linux-musl"
+            );
+            assert_eq!(
+                output.download_url,
+                "https://example.com/v1.0.0/tool-x86_64-unknown-linux-musl"
+            );
+        }
+    }
+
     mod secondary {
         use super::*;
 


### PR DESCRIPTION
Addresses moonrepo/proto#896.

Some tools name release assets with different arch strings per OS. The motivating case (from #896): buf uses `buf-Linux-aarch64` but `buf-Darwin-arm64` / `buf-Windows-arm64.exe`, so the global `[install.arch]` remap can't be right on all three platforms — today a TOML schema for buf silently resolves a nonexistent asset on Linux-arm64.

This adds optional `[platform.<os>.arch]` and `[platform.<os>.libc]` tables to the schema. Token resolution order: platform-scoped map → global `[install.*]` map → raw Rust value. Both new fields are `#[serde(default)]`, so existing schemas are unaffected.

For buf:

```toml
[install.arch]
aarch64 = "arm64"          # macOS, Windows

[platform.linux.arch]
aarch64 = "aarch64"        # identity override: Linux keeps the raw name
```

Identity overrides (platform value == raw value) intentionally shadow the global map and carry an explicit test — schemas distributed to mixed-version proto clients rely on "keep the global remap + identity-override one platform" as the only backwards-compatible migration shape (old engines ignore the unknown platform table and keep working).

Note the distinction from the existing `archs` list: `archs` *restricts* which architectures are supported; the new `arch` table *renames* the `{arch}` token.

This also covers #896's ripgrep example via the arch map alone, since the mapped value may embed a full triple: `x86_64 = "x86_64-unknown-linux-musl"`.

Includes tests (identity override, global fallback per-key, no-platform-table fallback, libc override) and a changelog entry. Docs PR for `non-wasm-plugin.mdx` (moonrepo/moon): incoming, will cross-link.