### PR TITLE
fix(rust_toolchain): install cargo-binstall with --locked

### DIFF
--- a/toolchains/rust/src/tier2_env.rs
+++ b/toolchains/rust/src/tier2_env.rs
@@ -80,7 +80,7 @@ pub fn setup_environment(
             output.commands.push(
                 create_command(
                     "cargo",
-                    vec!["install", &binstall_package, "--force"],
+                    vec!["install", &binstall_package, "--force", "--locked"],
                     &input.root,
                 )
                 .cache("cargo-binstall"),

--- a/toolchains/rust/tests/tier2_env_test.rs
+++ b/toolchains/rust/tests/tier2_env_test.rs
@@ -386,8 +386,11 @@ mod rust_toolchain_tier2 {
                 output.commands,
                 [
                     ExecCommand::new(
-                        ExecCommandInput::new("cargo", ["install", "cargo-binstall", "--force"],)
-                            .cwd(plugin.plugin.to_virtual_path(sandbox.path()))
+                        ExecCommandInput::new(
+                            "cargo",
+                            ["install", "cargo-binstall", "--force", "--locked"],
+                        )
+                        .cwd(plugin.plugin.to_virtual_path(sandbox.path()))
                     )
                     .cache("cargo-binstall"),
                     ExecCommand::new(
@@ -434,8 +437,11 @@ mod rust_toolchain_tier2 {
                 output.commands,
                 [
                     ExecCommand::new(
-                        ExecCommandInput::new("cargo", ["install", "cargo-binstall", "--force"],)
-                            .cwd(plugin.plugin.to_virtual_path(sandbox.path()))
+                        ExecCommandInput::new(
+                            "cargo",
+                            ["install", "cargo-binstall", "--force", "--locked"],
+                        )
+                        .cwd(plugin.plugin.to_virtual_path(sandbox.path()))
                     )
                     .cache("cargo-binstall"),
                     ExecCommand::new(
@@ -524,7 +530,7 @@ mod rust_toolchain_tier2 {
                     ExecCommand::new(
                         ExecCommandInput::new(
                             "cargo",
-                            ["install", "cargo-binstall@1.2.3", "--force"],
+                            ["install", "cargo-binstall@1.2.3", "--force", "--locked"],
                         )
                         .cwd(plugin.plugin.to_virtual_path(sandbox.path()))
                     )


### PR DESCRIPTION
cargo-binstall is failing to install without --locked

upstream recommends installing from source with --locked (see https://github.com/cargo-bins/cargo-binstall#from-source)