### PR TITLE
Ignore invalid unrelated package.json fields in JS detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,6 @@ version = "0.16.8"
 dependencies = [
  "extism-pdk",
  "lang_javascript_common",
- "nodejs_package_json",
  "proto_pdk",
  "proto_pdk_test_utils 0.45.1",
  "schematic",
@@ -2757,7 +2756,6 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 name = "lang_javascript_common"
 version = "0.1.0"
 dependencies = [
- "nodejs_package_json",
  "proto_pdk_api",
  "serde",
  "serde_json",
@@ -3282,7 +3280,6 @@ version = "0.18.1"
 dependencies = [
  "extism-pdk",
  "lang_javascript_common",
- "nodejs_package_json",
  "npmrc-config-rs",
  "proto_pdk",
  "proto_pdk_api",
@@ -3323,7 +3320,6 @@ version = "0.17.9"
 dependencies = [
  "extism-pdk",
  "lang_javascript_common",
- "nodejs_package_json",
  "proto_pdk",
  "proto_pdk_test_utils 0.45.1",
  "schematic",

--- a/crates/lang-javascript-common/Cargo.toml
+++ b/crates/lang-javascript-common/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT"
 publish = false
 
 [dependencies]
-nodejs_package_json = { workspace = true }
 proto_pdk_api = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/lang-javascript-common/src/package_json.rs
+++ b/crates/lang-javascript-common/src/package_json.rs
@@ -1,19 +1,11 @@
-use nodejs_package_json::{PackageJson, VersionProtocol};
 use proto_pdk_api::{AnyResult, VirtualPath};
 use starbase_utils::{
     fs,
     json::{self, JsonMap, JsonValue},
 };
 
-pub fn extract_valid_version_protocol(version_protocol: &VersionProtocol) -> Option<String> {
-    if matches!(
-        version_protocol,
-        VersionProtocol::Range(_) | VersionProtocol::Requirement(_) | VersionProtocol::Version(_)
-    ) {
-        Some(version_protocol.to_string())
-    } else {
-        None
-    }
+pub fn parse_package_json(content: &str) -> Option<JsonValue> {
+    json::parse::<JsonValue>(content).ok()
 }
 
 pub fn extract_version_from_text(content: &str) -> Option<&str> {
@@ -30,56 +22,51 @@ pub fn extract_version_from_text(content: &str) -> Option<&str> {
     None
 }
 
-pub fn extract_dev_engine_runtime_version(package_json: &PackageJson, key: &str) -> Option<String> {
-    if let Some(engines) = &package_json.dev_engines
-        && let Some(engine) = &engines.runtime
-    {
-        for item in engine.list() {
-            if item.name == key
-                && let Some(protocol) = &item.version
-                && let Some(version) = extract_valid_version_protocol(protocol)
-            {
-                return Some(version);
-            }
-        }
-    }
-
-    None
+pub fn extract_dev_engine_runtime_version(package_json: &JsonValue, key: &str) -> Option<String> {
+    extract_dev_engine_version(package_json, "runtime", key)
 }
 
 pub fn extract_dev_engine_package_manager_version(
-    package_json: &PackageJson,
+    package_json: &JsonValue,
     key: &str,
 ) -> Option<String> {
-    if let Some(engines) = &package_json.dev_engines
-        && let Some(engine) = &engines.package_manager
-    {
-        for item in engine.list() {
-            if item.name == key
-                && let Some(protocol) = &item.version
-                && let Some(version) = extract_valid_version_protocol(protocol)
-            {
-                return Some(version);
-            }
+    extract_dev_engine_version(package_json, "packageManager", key)
+}
+
+fn extract_dev_engine_version(package_json: &JsonValue, kind: &str, key: &str) -> Option<String> {
+    let engine = package_json.get("devEngines")?.get(kind)?;
+    let items = engine
+        .as_array()
+        .map(Vec::as_slice)
+        .unwrap_or_else(|| std::slice::from_ref(engine));
+
+    for item in items {
+        if item.get("name").and_then(JsonValue::as_str) == Some(key)
+            && let Some(version) = item.get("version").and_then(JsonValue::as_str)
+        {
+            return Some(version.to_owned());
         }
     }
 
     None
 }
 
-pub fn extract_engine_version(package_json: &PackageJson, key: &str) -> Option<String> {
-    if let Some(engines) = &package_json.engines {
-        return engines.get(key).and_then(extract_valid_version_protocol);
-    }
-
-    None
+pub fn extract_engine_version(package_json: &JsonValue, key: &str) -> Option<String> {
+    package_json
+        .get("engines")?
+        .get(key)?
+        .as_str()
+        .map(ToOwned::to_owned)
 }
 
 pub fn extract_package_manager_version<'a>(
-    package_json: &'a PackageJson,
+    package_json: &'a JsonValue,
     key: &str,
 ) -> Option<&'a str> {
-    if let Some(pm) = &package_json.package_manager {
+    if let Some(pm) = package_json
+        .get("packageManager")
+        .and_then(JsonValue::as_str)
+    {
         let mut parts = pm.split('@');
         let name = parts.next().unwrap_or_default();
 
@@ -103,22 +90,22 @@ pub fn extract_package_manager_version<'a>(
 }
 
 pub fn extract_volta_version(
-    package_json: &PackageJson,
+    package_json: &JsonValue,
     package_path: &VirtualPath,
     key: &str,
 ) -> AnyResult<Option<String>> {
-    if let Some(volta) = package_json.other_fields.get("volta") {
-        if let Some(json::JsonValue::String(inner)) = volta.get(key) {
+    if let Some(volta) = package_json.get("volta") {
+        if let Some(JsonValue::String(inner)) = volta.get(key) {
             return Ok(Some(inner.into()));
         }
 
-        if let Some(json::JsonValue::String(extends_from)) = volta.get("extends") {
+        if let Some(JsonValue::String(extends_from)) = volta.get("extends") {
             let extends_path = package_path.parent().unwrap().join(extends_from);
 
             if extends_path.exists() && extends_path.is_file() {
                 let content = fs::read_file(&extends_path)?;
 
-                if let Ok(other_package_json) = json::parse::<PackageJson>(&content) {
+                if let Some(other_package_json) = parse_package_json(&content) {
                     return extract_volta_version(&other_package_json, &extends_path, key);
                 }
             }

--- a/tools/bun/Cargo.toml
+++ b/tools/bun/Cargo.toml
@@ -21,7 +21,6 @@ crate-type = ["cdylib", "lib"]
 tool_common = { path = "../../crates/tool-common" }
 lang_javascript_common = { path = "../../crates/lang-javascript-common" }
 extism-pdk = { workspace = true }
-nodejs_package_json = { workspace = true }
 proto_pdk = { workspace = true }
 schematic = { workspace = true }
 serde = { workspace = true }

--- a/tools/bun/src/proto.rs
+++ b/tools/bun/src/proto.rs
@@ -3,9 +3,8 @@ use extism_pdk::*;
 use lang_javascript_common::{
     extract_dev_engine_package_manager_version, extract_dev_engine_runtime_version,
     extract_engine_version, extract_package_manager_version, extract_version_from_text,
-    extract_volta_version, insert_dev_engine_version, remove_dev_engine,
+    extract_volta_version, insert_dev_engine_version, parse_package_json, remove_dev_engine,
 };
-use nodejs_package_json::PackageJson;
 use proto_pdk::*;
 use schematic::SchemaBuilder;
 use std::collections::HashMap;
@@ -58,7 +57,7 @@ pub fn parse_version_file(
     let mut version = None;
 
     if input.file == "package.json" {
-        if let Ok(package_json) = json::from_str::<PackageJson>(&input.content) {
+        if let Some(package_json) = parse_package_json(&input.content) {
             if let Some(constraint) = extract_dev_engine_runtime_version(&package_json, "bun") {
                 version = Some(UnresolvedVersionSpec::parse(constraint)?);
             } else if let Some(constraint) =

--- a/tools/node-depman/Cargo.toml
+++ b/tools/node-depman/Cargo.toml
@@ -21,7 +21,6 @@ crate-type = ["cdylib", "lib"]
 tool_common = { path = "../../crates/tool-common" }
 lang_javascript_common = { path = "../../crates/lang-javascript-common" }
 extism-pdk = { workspace = true }
-nodejs_package_json = { workspace = true }
 npmrc-config-rs = "0.1.1"
 proto_pdk = { workspace = true }
 rustc-hash = { workspace = true }

--- a/tools/node-depman/src/proto.rs
+++ b/tools/node-depman/src/proto.rs
@@ -5,9 +5,8 @@ use extism_pdk::*;
 use lang_javascript_common::{
     NodeDistVersion, extract_dev_engine_package_manager_version, extract_engine_version,
     extract_package_manager_version, extract_volta_version, insert_dev_engine_version,
-    remove_dev_engine,
+    parse_package_json, remove_dev_engine,
 };
-use nodejs_package_json::PackageJson;
 use proto_pdk::*;
 use rustc_hash::FxHashMap;
 use schematic::SchemaBuilder;
@@ -66,7 +65,7 @@ pub fn parse_version_file(
     let mut version = None;
 
     if input.file == "package.json"
-        && let Ok(package_json) = json::from_str::<PackageJson>(&input.content)
+        && let Some(package_json) = parse_package_json(&input.content)
     {
         let manager_name = PackageManager::detect()?.to_string();
 

--- a/tools/node-depman/tests/versions_test.rs
+++ b/tools/node-depman/tests/versions_test.rs
@@ -272,6 +272,44 @@ mod node_depman_tool {
         }
 
         #[tokio::test(flavor = "multi_thread")]
+        async fn parses_dev_engines_list() {
+            let sandbox = create_empty_proto_sandbox();
+            let plugin = sandbox.create_plugin("pnpm-test").await;
+
+            assert_eq!(
+                plugin
+                    .parse_version_file(ParseVersionFileInput {
+                        content: r#"{ "devEngines": { "packageManager": [{ "name": "npm", "version": "1.2.3" }, { "name": "pnpm", "version": "4.5.6" }] } }"#.into(),
+                        file: "package.json".into(),
+                        ..Default::default()
+                    })
+                    .await,
+                ParseVersionFileOutput {
+                    version: Some(UnresolvedVersionSpec::parse("4.5.6").unwrap()),
+                }
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn parses_dev_engines_when_unrelated_node_engine_is_invalid() {
+            let sandbox = create_empty_proto_sandbox();
+            let plugin = sandbox.create_plugin("pnpm-test").await;
+
+            assert_eq!(
+                plugin
+                    .parse_version_file(ParseVersionFileInput {
+                        content: r#"{ "engines": { "node": ">= nope" }, "devEngines": { "packageManager": { "name": "pnpm", "version": "1.2.3" } } }"#.into(),
+                        file: "package.json".into(),
+                        ..Default::default()
+                    })
+                    .await,
+                ParseVersionFileOutput {
+                    version: Some(UnresolvedVersionSpec::parse("1.2.3").unwrap()),
+                }
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
         async fn parses_volta() {
             let sandbox = create_empty_proto_sandbox();
             let plugin = sandbox.create_plugin("pnpm-test").await;

--- a/tools/node/Cargo.toml
+++ b/tools/node/Cargo.toml
@@ -21,7 +21,6 @@ crate-type = ["cdylib", "lib"]
 tool_common = { path = "../../crates/tool-common" }
 lang_javascript_common = { path = "../../crates/lang-javascript-common" }
 extism-pdk = { workspace = true }
-nodejs_package_json = { workspace = true }
 proto_pdk = { workspace = true }
 schematic = { workspace = true }
 serde = { workspace = true }

--- a/tools/node/src/proto.rs
+++ b/tools/node/src/proto.rs
@@ -2,9 +2,9 @@ use crate::config::NodeToolConfig;
 use extism_pdk::*;
 use lang_javascript_common::{
     NodeDistLTS, NodeDistVersion, extract_dev_engine_runtime_version, extract_engine_version,
-    extract_version_from_text, extract_volta_version, insert_dev_engine_version, remove_dev_engine,
+    extract_version_from_text, extract_volta_version, insert_dev_engine_version,
+    parse_package_json, remove_dev_engine,
 };
-use nodejs_package_json::PackageJson;
 use proto_pdk::*;
 use schematic::SchemaBuilder;
 use std::collections::HashMap;
@@ -56,7 +56,7 @@ pub fn parse_version_file(
     let mut version = None;
 
     if input.file == "package.json" {
-        if let Ok(package_json) = json::from_str::<PackageJson>(&input.content) {
+        if let Some(package_json) = parse_package_json(&input.content) {
             if let Some(constraint) = extract_dev_engine_runtime_version(&package_json, "node") {
                 version = Some(UnresolvedVersionSpec::parse(constraint)?);
             }


### PR DESCRIPTION
## Summary

JavaScript tool version detection reads several `package.json` fields in priority order, including `devEngines`, `packageManager`, Volta, and `engines`. The detection path parsed the entire manifest through `nodejs_package_json::PackageJson` before looking at those individual fields, so one malformed version-like field could prevent discovery from reaching an unrelated valid field.

This PR changes detection to parse `package.json` as raw JSON first, then extract only the candidate strings relevant to the active tool. Node, Bun, and node-depman keep their existing source precedence, and the selected candidate is still parsed through `UnresolvedVersionSpec`, so malformed authoritative values for the active tool still fail.

The shared extraction covers `devEngines` object and array forms, `engines`, `packageManager` values with Corepack hashes, and Volta including `extends`. The affected crates no longer depend directly on `nodejs_package_json` for detection.

Fixes #159.

## Verification

- `cargo build -p node_tool -p node_depman_tool -p bun_tool --target wasm32-wasip1`
- `cargo test -p node_tool --no-default-features --test versions_test`
- `cargo test -p node_depman_tool --no-default-features --test versions_test`
- `cargo test -p bun_tool --no-default-features --test versions_test`
