### PR TITLE
feat: use prebuilt jdx Ruby binaries if available

### DIFF
--- a/scripts/generateRubyReleases.mjs
+++ b/scripts/generateRubyReleases.mjs
@@ -1,0 +1,70 @@
+// @ts-check
+import fs from "node:fs";
+
+const GH_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+const RELEASES_PATH = "tools/ruby/releases.json";
+const data = fs.existsSync(RELEASES_PATH)
+  ? JSON.parse(fs.readFileSync(RELEASES_PATH, "utf8"))
+  : {};
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  ...(GH_TOKEN ? { Authorization: `Bearer ${GH_TOKEN}` } : {}),
+};
+
+let page = 1;
+
+while (true) {
+  console.log(`Loading page ${page}`);
+
+  const response = await fetch(
+    `https://api.github.com/repos/jdx/ruby/releases?per_page=100&page=${page}`,
+    { headers },
+  );
+
+  if (!response.ok) {
+    throw new Error(`GitHub API returned HTTP ${response.status}`);
+  }
+
+  const releases = await response.json();
+
+  for (const release of releases) {
+    const version = release.tag_name;
+
+    // Ignore immutable build revisions, such as 3.4.9-1.
+    if (!/^\d+\.\d+\.\d+(?:-(?:preview|rc)\d+)?$/.test(version)) {
+      continue;
+    }
+
+    for (const asset of release.assets) {
+      const match = asset.name.match(
+        /^ruby-(.+)\.(macos|x86_64_linux|arm64_linux)\.tar\.gz$/,
+      );
+
+      if (!match || match[1] !== version) {
+        continue;
+      }
+
+      data[version] ||= {};
+      data[version][match[2]] = asset.name;
+    }
+  }
+
+  const link = response.headers.get("link");
+
+  if (!link?.includes('rel="next"')) {
+    break;
+  }
+
+  page += 1;
+}
+
+function sortObjectKeys(value) {
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
+      .map(([key, item]) => [key, typeof item === "object" ? sortObjectKeys(item) : item]),
+  );
+}
+
+fs.writeFileSync(RELEASES_PATH, `${JSON.stringify(sortObjectKeys(data), null, 2)}\n`);

--- a/tools/ruby/CHANGELOG.md
+++ b/tools/ruby/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🚀 Updates
+
+- Added support for installing portable Ruby binaries from `jdx/ruby` when available.
+
 ## 0.2.8
 
 #### 🚀 Updates

--- a/tools/ruby/README.md
+++ b/tools/ruby/README.md
@@ -37,3 +37,9 @@ Test the plugins by running `proto` commands.
 proto install ruby-test
 proto versions ruby-test
 ```
+
+Update the cached list of portable Ruby binaries after jdx publishes new releases:
+
+```shell
+node scripts/generateRubyReleases.mjs
+```

--- a/tools/ruby/releases.json
+++ b/tools/ruby/releases.json
@@ -1,0 +1,227 @@
+{
+  "3.2.1": {
+    "arm64_linux": "ruby-3.2.1.arm64_linux.tar.gz",
+    "macos": "ruby-3.2.1.macos.tar.gz",
+    "x86_64_linux": "ruby-3.2.1.x86_64_linux.tar.gz"
+  },
+  "3.2.2": {
+    "arm64_linux": "ruby-3.2.2.arm64_linux.tar.gz",
+    "macos": "ruby-3.2.2.macos.tar.gz",
+    "x86_64_linux": "ruby-3.2.2.x86_64_linux.tar.gz"
+  },
+  "3.2.3": {
+    "arm64_linux": "ruby-3.2.3.arm64_linux.tar.gz",
+    "macos": "ruby-3.2.3.macos.tar.gz",
+    "x86_64_linux": "ruby-3.2.3.x86_64_linux.tar.gz"
+  },
+  "3.2.4": {
+    "arm64_linux": "ruby-3.2.4.arm64_linux.tar.gz",
+    "macos": "ruby-3.2.4.macos.tar.gz",
+    "x86_64_linux": "ruby-3.2.4.x86_64_linux.tar.gz"
+  },
+  "3.2.5": {
+    "arm64_linux": "ruby-3.2.5.arm64_linux.tar.gz",
+    "macos": "ruby-3.2.5.macos.tar.gz",
+    "x86_64_linux": "ruby-3.2.5.x86_64_linux.tar.gz"
+  },
+  "3.2.6": {
+    "arm64_linux": "ruby-3.2.6.arm64_linux.tar.gz",
+    "macos": "ruby-3.2.6.macos.tar.gz",
+    "x86_64_linux": "ruby-3.2.6.x86_64_linux.tar.gz"
+  },
+  "3.2.7": {
+    "arm64_linux": "ruby-3.2.7.arm64_linux.tar.gz",
+    "macos": "ruby-3.2.7.macos.tar.gz",
+    "x86_64_linux": "ruby-3.2.7.x86_64_linux.tar.gz"
+  },
+  "3.2.8": {
+    "arm64_linux": "ruby-3.2.8.arm64_linux.tar.gz",
+    "macos": "ruby-3.2.8.macos.tar.gz",
+    "x86_64_linux": "ruby-3.2.8.x86_64_linux.tar.gz"
+  },
+  "3.2.9": {
+    "arm64_linux": "ruby-3.2.9.arm64_linux.tar.gz",
+    "macos": "ruby-3.2.9.macos.tar.gz",
+    "x86_64_linux": "ruby-3.2.9.x86_64_linux.tar.gz"
+  },
+  "3.2.10": {
+    "arm64_linux": "ruby-3.2.10.arm64_linux.tar.gz",
+    "macos": "ruby-3.2.10.macos.tar.gz",
+    "x86_64_linux": "ruby-3.2.10.x86_64_linux.tar.gz"
+  },
+  "3.2.11": {
+    "arm64_linux": "ruby-3.2.11.arm64_linux.tar.gz",
+    "macos": "ruby-3.2.11.macos.tar.gz",
+    "x86_64_linux": "ruby-3.2.11.x86_64_linux.tar.gz"
+  },
+  "3.3.0": {
+    "arm64_linux": "ruby-3.3.0.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.0.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.0.x86_64_linux.tar.gz"
+  },
+  "3.3.1": {
+    "arm64_linux": "ruby-3.3.1.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.1.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.1.x86_64_linux.tar.gz"
+  },
+  "3.3.2": {
+    "arm64_linux": "ruby-3.3.2.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.2.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.2.x86_64_linux.tar.gz"
+  },
+  "3.3.3": {
+    "arm64_linux": "ruby-3.3.3.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.3.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.3.x86_64_linux.tar.gz"
+  },
+  "3.3.4": {
+    "arm64_linux": "ruby-3.3.4.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.4.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.4.x86_64_linux.tar.gz"
+  },
+  "3.3.5": {
+    "arm64_linux": "ruby-3.3.5.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.5.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.5.x86_64_linux.tar.gz"
+  },
+  "3.3.6": {
+    "arm64_linux": "ruby-3.3.6.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.6.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.6.x86_64_linux.tar.gz"
+  },
+  "3.3.7": {
+    "arm64_linux": "ruby-3.3.7.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.7.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.7.x86_64_linux.tar.gz"
+  },
+  "3.3.8": {
+    "arm64_linux": "ruby-3.3.8.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.8.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.8.x86_64_linux.tar.gz"
+  },
+  "3.3.9": {
+    "arm64_linux": "ruby-3.3.9.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.9.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.9.x86_64_linux.tar.gz"
+  },
+  "3.3.10": {
+    "arm64_linux": "ruby-3.3.10.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.10.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.10.x86_64_linux.tar.gz"
+  },
+  "3.3.11": {
+    "arm64_linux": "ruby-3.3.11.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.11.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.11.x86_64_linux.tar.gz"
+  },
+  "3.3.12": {
+    "arm64_linux": "ruby-3.3.12.arm64_linux.tar.gz",
+    "macos": "ruby-3.3.12.macos.tar.gz",
+    "x86_64_linux": "ruby-3.3.12.x86_64_linux.tar.gz"
+  },
+  "3.4.0": {
+    "arm64_linux": "ruby-3.4.0.arm64_linux.tar.gz",
+    "macos": "ruby-3.4.0.macos.tar.gz",
+    "x86_64_linux": "ruby-3.4.0.x86_64_linux.tar.gz"
+  },
+  "3.4.1": {
+    "arm64_linux": "ruby-3.4.1.arm64_linux.tar.gz",
+    "macos": "ruby-3.4.1.macos.tar.gz",
+    "x86_64_linux": "ruby-3.4.1.x86_64_linux.tar.gz"
+  },
+  "3.4.2": {
+    "arm64_linux": "ruby-3.4.2.arm64_linux.tar.gz",
+    "macos": "ruby-3.4.2.macos.tar.gz",
+    "x86_64_linux": "ruby-3.4.2.x86_64_linux.tar.gz"
+  },
+  "3.4.3": {
+    "arm64_linux": "ruby-3.4.3.arm64_linux.tar.gz",
+    "macos": "ruby-3.4.3.macos.tar.gz",
+    "x86_64_linux": "ruby-3.4.3.x86_64_linux.tar.gz"
+  },
+  "3.4.4": {
+    "arm64_linux": "ruby-3.4.4.arm64_linux.tar.gz",
+    "macos": "ruby-3.4.4.macos.tar.gz",
+    "x86_64_linux": "ruby-3.4.4.x86_64_linux.tar.gz"
+  },
+  "3.4.5": {
+    "arm64_linux": "ruby-3.4.5.arm64_linux.tar.gz",
+    "macos": "ruby-3.4.5.macos.tar.gz",
+    "x86_64_linux": "ruby-3.4.5.x86_64_linux.tar.gz"
+  },
+  "3.4.6": {
+    "arm64_linux": "ruby-3.4.6.arm64_linux.tar.gz",
+    "macos": "ruby-3.4.6.macos.tar.gz",
+    "x86_64_linux": "ruby-3.4.6.x86_64_linux.tar.gz"
+  },
+  "3.4.7": {
+    "arm64_linux": "ruby-3.4.7.arm64_linux.tar.gz",
+    "macos": "ruby-3.4.7.macos.tar.gz",
+    "x86_64_linux": "ruby-3.4.7.x86_64_linux.tar.gz"
+  },
+  "3.4.8": {
+    "arm64_linux": "ruby-3.4.8.arm64_linux.tar.gz",
+    "macos": "ruby-3.4.8.macos.tar.gz",
+    "x86_64_linux": "ruby-3.4.8.x86_64_linux.tar.gz"
+  },
+  "3.4.9": {
+    "arm64_linux": "ruby-3.4.9.arm64_linux.tar.gz",
+    "macos": "ruby-3.4.9.macos.tar.gz",
+    "x86_64_linux": "ruby-3.4.9.x86_64_linux.tar.gz"
+  },
+  "3.4.10": {
+    "arm64_linux": "ruby-3.4.10.arm64_linux.tar.gz",
+    "macos": "ruby-3.4.10.macos.tar.gz",
+    "x86_64_linux": "ruby-3.4.10.x86_64_linux.tar.gz"
+  },
+  "3.5.0-preview1": {
+    "arm64_linux": "ruby-3.5.0-preview1.arm64_linux.tar.gz",
+    "macos": "ruby-3.5.0-preview1.macos.tar.gz",
+    "x86_64_linux": "ruby-3.5.0-preview1.x86_64_linux.tar.gz"
+  },
+  "4.0.0": {
+    "arm64_linux": "ruby-4.0.0.arm64_linux.tar.gz",
+    "macos": "ruby-4.0.0.macos.tar.gz",
+    "x86_64_linux": "ruby-4.0.0.x86_64_linux.tar.gz"
+  },
+  "4.0.0-preview2": {
+    "arm64_linux": "ruby-4.0.0-preview2.arm64_linux.tar.gz",
+    "macos": "ruby-4.0.0-preview2.macos.tar.gz",
+    "x86_64_linux": "ruby-4.0.0-preview2.x86_64_linux.tar.gz"
+  },
+  "4.0.0-preview3": {
+    "arm64_linux": "ruby-4.0.0-preview3.arm64_linux.tar.gz",
+    "macos": "ruby-4.0.0-preview3.macos.tar.gz",
+    "x86_64_linux": "ruby-4.0.0-preview3.x86_64_linux.tar.gz"
+  },
+  "4.0.1": {
+    "arm64_linux": "ruby-4.0.1.arm64_linux.tar.gz",
+    "macos": "ruby-4.0.1.macos.tar.gz",
+    "x86_64_linux": "ruby-4.0.1.x86_64_linux.tar.gz"
+  },
+  "4.0.2": {
+    "arm64_linux": "ruby-4.0.2.arm64_linux.tar.gz",
+    "macos": "ruby-4.0.2.macos.tar.gz",
+    "x86_64_linux": "ruby-4.0.2.x86_64_linux.tar.gz"
+  },
+  "4.0.3": {
+    "arm64_linux": "ruby-4.0.3.arm64_linux.tar.gz",
+    "macos": "ruby-4.0.3.macos.tar.gz",
+    "x86_64_linux": "ruby-4.0.3.x86_64_linux.tar.gz"
+  },
+  "4.0.4": {
+    "arm64_linux": "ruby-4.0.4.arm64_linux.tar.gz",
+    "macos": "ruby-4.0.4.macos.tar.gz",
+    "x86_64_linux": "ruby-4.0.4.x86_64_linux.tar.gz"
+  },
+  "4.0.5": {
+    "arm64_linux": "ruby-4.0.5.arm64_linux.tar.gz",
+    "macos": "ruby-4.0.5.macos.tar.gz",
+    "x86_64_linux": "ruby-4.0.5.x86_64_linux.tar.gz"
+  },
+  "4.0.6": {
+    "arm64_linux": "ruby-4.0.6.arm64_linux.tar.gz",
+    "macos": "ruby-4.0.6.macos.tar.gz",
+    "x86_64_linux": "ruby-4.0.6.x86_64_linux.tar.gz"
+  }
+}

--- a/tools/ruby/src/proto.rs
+++ b/tools/ruby/src/proto.rs
@@ -5,6 +5,12 @@ use tool_common::enable_tracing;
 
 type PrebuiltReleases = BTreeMap<String, BTreeMap<String, String>>;
 
+#[derive(Debug, PartialEq)]
+struct PrebuiltAsset {
+    filename: String,
+    url: String,
+}
+
 #[host_fn]
 extern "ExtismHost" {
     fn exec_command(input: Json<ExecCommandInput>) -> Json<ExecCommandOutput>;
@@ -137,29 +143,66 @@ fn find_prebuilt_source(
     env: &HostEnvironment,
     version: &VersionSpec,
 ) -> AnyResult<Option<SourceLocation>> {
+    let version = version.to_string();
+
+    Ok(load_prebuilt_asset(env, &version)?.map(|asset| {
+        SourceLocation::Archive(ArchiveSource {
+            url: asset.url,
+            prefix: Some(format!("ruby-{version}")),
+        })
+    }))
+}
+
+#[plugin_fn]
+pub fn download_prebuilt(
+    Json(input): Json<DownloadPrebuiltInput>,
+) -> FnResult<Json<DownloadPrebuiltOutput>> {
+    let env = get_host_environment()?;
+    let version = input.context.version.to_string();
+
+    let Some(asset) = load_prebuilt_asset(&env, &version)? else {
+        return Err(plugin_err!(
+            "No pre-built available for Ruby <hash>{version}</hash> on <id>{}-{}</id>! Try building from source with <shell>--build</shell>.",
+            env.os,
+            env.arch,
+        ));
+    };
+
+    Ok(Json(create_download_output(asset, &version)))
+}
+
+fn load_prebuilt_asset(env: &HostEnvironment, version: &str) -> AnyResult<Option<PrebuiltAsset>> {
     let Some(platform) = get_prebuilt_platform(env) else {
         return Ok(None);
     };
 
-    let version = version.to_string();
     let releases: PrebuiltReleases = fetch_json(
         "https://raw.githubusercontent.com/moonrepo/plugins/master/tools/ruby/releases.json",
     )?;
 
-    Ok(select_prebuilt_source(&releases, platform, &version))
+    Ok(select_prebuilt_asset(&releases, platform, version))
 }
 
-fn select_prebuilt_source(
+fn select_prebuilt_asset(
     releases: &PrebuiltReleases,
     platform: &str,
     version: &str,
-) -> Option<SourceLocation> {
+) -> Option<PrebuiltAsset> {
     let filename = releases.get(version)?.get(platform)?;
 
-    Some(SourceLocation::Archive(ArchiveSource {
+    Some(PrebuiltAsset {
+        filename: filename.to_owned(),
         url: format!("https://github.com/jdx/ruby/releases/download/{version}/{filename}"),
-        prefix: Some(format!("ruby-{version}")),
-    }))
+    })
+}
+
+fn create_download_output(asset: PrebuiltAsset, version: &str) -> DownloadPrebuiltOutput {
+    DownloadPrebuiltOutput {
+        archive_prefix: Some(format!("ruby-{version}")),
+        download_name: Some(asset.filename),
+        download_url: asset.url,
+        ..DownloadPrebuiltOutput::default()
+    }
 }
 
 fn get_prebuilt_platform(env: &HostEnvironment) -> Option<&'static str> {
@@ -232,7 +275,7 @@ mod tests {
 
     #[test]
     fn selects_matching_release_asset() {
-        let source = select_prebuilt_source(
+        let asset = select_prebuilt_asset(
             &BTreeMap::from_iter([(
                 "3.4.9".into(),
                 BTreeMap::from_iter([(
@@ -245,29 +288,48 @@ mod tests {
         );
 
         assert_eq!(
-            source,
-            Some(SourceLocation::Archive(ArchiveSource {
+            asset,
+            Some(PrebuiltAsset {
+                filename: "ruby-3.4.9.arm64_linux.tar.gz".into(),
                 url: "https://github.com/jdx/ruby/releases/download/3.4.9/ruby-3.4.9.arm64_linux.tar.gz".into(),
-                prefix: Some("ruby-3.4.9".into()),
-            }))
+            })
         );
     }
 
     #[test]
     fn skips_release_without_matching_asset() {
-        let source = select_prebuilt_source(
+        let asset = select_prebuilt_asset(
             &BTreeMap::from_iter([("3.4.9".into(), BTreeMap::new())]),
             "macos",
             "3.4.9",
         );
 
-        assert_eq!(source, None);
+        assert_eq!(asset, None);
     }
 
     #[test]
     fn skips_missing_release() {
-        let source = select_prebuilt_source(&BTreeMap::new(), "macos", "3.1.0");
+        let asset = select_prebuilt_asset(&BTreeMap::new(), "macos", "3.1.0");
 
-        assert_eq!(source, None);
+        assert_eq!(asset, None);
+    }
+
+    #[test]
+    fn creates_download_output() {
+        assert_eq!(
+            create_download_output(
+                PrebuiltAsset {
+                    filename: "ruby-3.4.9.macos.tar.gz".into(),
+                    url: "https://example.com/ruby-3.4.9.macos.tar.gz".into(),
+                },
+                "3.4.9",
+            ),
+            DownloadPrebuiltOutput {
+                archive_prefix: Some("ruby-3.4.9".into()),
+                download_name: Some("ruby-3.4.9.macos.tar.gz".into()),
+                download_url: "https://example.com/ruby-3.4.9.macos.tar.gz".into(),
+                ..DownloadPrebuiltOutput::default()
+            }
+        );
     }
 }

--- a/tools/ruby/src/proto.rs
+++ b/tools/ruby/src/proto.rs
@@ -1,7 +1,20 @@
 use extism_pdk::*;
 use proto_pdk::*;
+use serde::Deserialize;
 use std::collections::HashMap;
 use tool_common::enable_tracing;
+
+#[derive(Deserialize)]
+struct GitHubAsset {
+    browser_download_url: String,
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct GitHubRelease {
+    assets: Vec<GitHubAsset>,
+    tag_name: String,
+}
 
 #[host_fn]
 extern "ExtismHost" {
@@ -68,6 +81,13 @@ pub fn build_instructions(
         return Err(PluginError::UnsupportedWindowsBuild.into());
     }
 
+    if let Some(source) = find_prebuilt_source(&env, &version)? {
+        return Ok(Json(BuildInstructionsOutput {
+            source: Some(source),
+            ..BuildInstructionsOutput::default()
+        }));
+    }
+
     let output = BuildInstructionsOutput {
         help_url: Some(
             "https://github.com/rbenv/ruby-build/wiki".into(),
@@ -124,6 +144,65 @@ pub fn build_instructions(
     Ok(Json(output))
 }
 
+fn find_prebuilt_source(
+    env: &HostEnvironment,
+    version: &VersionSpec,
+) -> AnyResult<Option<SourceLocation>> {
+    let Some(platform) = get_prebuilt_platform(env) else {
+        return Ok(None);
+    };
+
+    let version = version.to_string();
+    let filename = format!("ruby-{version}.{platform}.tar.gz");
+    const PAGE_SIZE: usize = 100;
+    let mut page = 1;
+
+    loop {
+        let releases: Vec<GitHubRelease> = fetch_json(format!(
+            "https://api.github.com/repos/jdx/ruby/releases?per_page={PAGE_SIZE}&page={page}"
+        ))?;
+        let is_last_page = releases.len() < PAGE_SIZE;
+
+        if let Some(source) = select_prebuilt_source(releases, &filename, &version) {
+            return Ok(Some(source));
+        }
+
+        if is_last_page {
+            return Ok(None);
+        }
+
+        page += 1;
+    }
+}
+
+fn select_prebuilt_source(
+    releases: Vec<GitHubRelease>,
+    filename: &str,
+    version: &str,
+) -> Option<SourceLocation> {
+    releases
+        .into_iter()
+        .find(|release| release.tag_name == version)?
+        .assets
+        .into_iter()
+        .find(|asset| asset.name == filename)
+        .map(|asset| {
+            SourceLocation::Archive(ArchiveSource {
+                url: asset.browser_download_url,
+                prefix: Some(format!("ruby-{version}")),
+            })
+        })
+}
+
+fn get_prebuilt_platform(env: &HostEnvironment) -> Option<&'static str> {
+    match (env.os, env.arch) {
+        (HostOS::Linux, HostArch::X64) => Some("x86_64_linux"),
+        (HostOS::Linux, HostArch::Arm64) => Some("arm64_linux"),
+        (HostOS::MacOS, HostArch::Arm64) => Some("macos"),
+        _ => None,
+    }
+}
+
 #[plugin_fn]
 pub fn locate_executables(
     Json(_): Json<LocateExecutablesInput>,
@@ -157,4 +236,73 @@ pub fn locate_executables(
         globals_lookup_dirs: vec![],
         ..LocateExecutablesOutput::default()
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_jdx_supported_platforms() {
+        for (os, arch, expected) in [
+            (HostOS::Linux, HostArch::X64, Some("x86_64_linux")),
+            (HostOS::Linux, HostArch::Arm64, Some("arm64_linux")),
+            (HostOS::MacOS, HostArch::Arm64, Some("macos")),
+            (HostOS::MacOS, HostArch::X64, None),
+            (HostOS::Windows, HostArch::X64, None),
+        ] {
+            assert_eq!(
+                get_prebuilt_platform(&HostEnvironment {
+                    os,
+                    arch,
+                    ..HostEnvironment::default()
+                }),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn selects_matching_release_asset() {
+        let source = select_prebuilt_source(
+            vec![GitHubRelease {
+                assets: vec![GitHubAsset {
+                    browser_download_url: "https://example.com/ruby.tar.gz".into(),
+                    name: "ruby-3.4.9.arm64_linux.tar.gz".into(),
+                }],
+                tag_name: "3.4.9".into(),
+            }],
+            "ruby-3.4.9.arm64_linux.tar.gz",
+            "3.4.9",
+        );
+
+        assert_eq!(
+            source,
+            Some(SourceLocation::Archive(ArchiveSource {
+                url: "https://example.com/ruby.tar.gz".into(),
+                prefix: Some("ruby-3.4.9".into()),
+            }))
+        );
+    }
+
+    #[test]
+    fn skips_release_without_matching_asset() {
+        let source = select_prebuilt_source(
+            vec![GitHubRelease {
+                assets: vec![],
+                tag_name: "3.4.9".into(),
+            }],
+            "ruby-3.4.9.macos.tar.gz",
+            "3.4.9",
+        );
+
+        assert_eq!(source, None);
+    }
+
+    #[test]
+    fn skips_missing_release() {
+        let source = select_prebuilt_source(vec![], "ruby-3.1.0.macos.tar.gz", "3.1.0");
+
+        assert_eq!(source, None);
+    }
 }

--- a/tools/ruby/src/proto.rs
+++ b/tools/ruby/src/proto.rs
@@ -1,20 +1,9 @@
 use extism_pdk::*;
 use proto_pdk::*;
-use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use tool_common::enable_tracing;
 
-#[derive(Deserialize)]
-struct GitHubAsset {
-    browser_download_url: String,
-    name: String,
-}
-
-#[derive(Deserialize)]
-struct GitHubRelease {
-    assets: Vec<GitHubAsset>,
-    tag_name: String,
-}
+type PrebuiltReleases = BTreeMap<String, BTreeMap<String, String>>;
 
 #[host_fn]
 extern "ExtismHost" {
@@ -153,45 +142,24 @@ fn find_prebuilt_source(
     };
 
     let version = version.to_string();
-    let filename = format!("ruby-{version}.{platform}.tar.gz");
-    const PAGE_SIZE: usize = 100;
-    let mut page = 1;
+    let releases: PrebuiltReleases = fetch_json(
+        "https://raw.githubusercontent.com/moonrepo/plugins/master/tools/ruby/releases.json",
+    )?;
 
-    loop {
-        let releases: Vec<GitHubRelease> = fetch_json(format!(
-            "https://api.github.com/repos/jdx/ruby/releases?per_page={PAGE_SIZE}&page={page}"
-        ))?;
-        let is_last_page = releases.len() < PAGE_SIZE;
-
-        if let Some(source) = select_prebuilt_source(releases, &filename, &version) {
-            return Ok(Some(source));
-        }
-
-        if is_last_page {
-            return Ok(None);
-        }
-
-        page += 1;
-    }
+    Ok(select_prebuilt_source(&releases, platform, &version))
 }
 
 fn select_prebuilt_source(
-    releases: Vec<GitHubRelease>,
-    filename: &str,
+    releases: &PrebuiltReleases,
+    platform: &str,
     version: &str,
 ) -> Option<SourceLocation> {
-    releases
-        .into_iter()
-        .find(|release| release.tag_name == version)?
-        .assets
-        .into_iter()
-        .find(|asset| asset.name == filename)
-        .map(|asset| {
-            SourceLocation::Archive(ArchiveSource {
-                url: asset.browser_download_url,
-                prefix: Some(format!("ruby-{version}")),
-            })
-        })
+    let filename = releases.get(version)?.get(platform)?;
+
+    Some(SourceLocation::Archive(ArchiveSource {
+        url: format!("https://github.com/jdx/ruby/releases/download/{version}/{filename}"),
+        prefix: Some(format!("ruby-{version}")),
+    }))
 }
 
 fn get_prebuilt_platform(env: &HostEnvironment) -> Option<&'static str> {
@@ -265,21 +233,21 @@ mod tests {
     #[test]
     fn selects_matching_release_asset() {
         let source = select_prebuilt_source(
-            vec![GitHubRelease {
-                assets: vec![GitHubAsset {
-                    browser_download_url: "https://example.com/ruby.tar.gz".into(),
-                    name: "ruby-3.4.9.arm64_linux.tar.gz".into(),
-                }],
-                tag_name: "3.4.9".into(),
-            }],
-            "ruby-3.4.9.arm64_linux.tar.gz",
+            &BTreeMap::from_iter([(
+                "3.4.9".into(),
+                BTreeMap::from_iter([(
+                    "arm64_linux".into(),
+                    "ruby-3.4.9.arm64_linux.tar.gz".into(),
+                )]),
+            )]),
+            "arm64_linux",
             "3.4.9",
         );
 
         assert_eq!(
             source,
             Some(SourceLocation::Archive(ArchiveSource {
-                url: "https://example.com/ruby.tar.gz".into(),
+                url: "https://github.com/jdx/ruby/releases/download/3.4.9/ruby-3.4.9.arm64_linux.tar.gz".into(),
                 prefix: Some("ruby-3.4.9".into()),
             }))
         );
@@ -288,11 +256,8 @@ mod tests {
     #[test]
     fn skips_release_without_matching_asset() {
         let source = select_prebuilt_source(
-            vec![GitHubRelease {
-                assets: vec![],
-                tag_name: "3.4.9".into(),
-            }],
-            "ruby-3.4.9.macos.tar.gz",
+            &BTreeMap::from_iter([("3.4.9".into(), BTreeMap::new())]),
+            "macos",
             "3.4.9",
         );
 
@@ -301,7 +266,7 @@ mod tests {
 
     #[test]
     fn skips_missing_release() {
-        let source = select_prebuilt_source(vec![], "ruby-3.1.0.macos.tar.gz", "3.1.0");
+        let source = select_prebuilt_source(&BTreeMap::new(), "macos", "3.1.0");
 
         assert_eq!(source, None);
     }


### PR DESCRIPTION
Adds a downloaded to pull the selected ruby version prebuilt binary from https://github.com/jdx/ruby/
if no prebuilt version is prebuilt, falls back to build from source