### PR TITLE
fix: Detect incomplete Rust toolchains

### DIFF
--- a/tools/rust/src/proto.rs
+++ b/tools/rust/src/proto.rs
@@ -165,8 +165,12 @@ pub fn native_install(
         .lines()
         .any(|line| line.starts_with(&triple))
     {
-        // Ensure the bins exist and that this isn't just an empty folder
-        if input.install_dir.join("bin").exists() {
+        // Ensure the primary executable exists.
+        if input
+            .install_dir
+            .join(env.os.get_exe_name("bin/cargo"))
+            .exists()
+        {
             debug!("Target already installed in toolchain");
 
             do_install = false;


### PR DESCRIPTION
A rustup toolchain can be registered while missing Cargo. The Rust plugin currently treats any existing `bin` directory as installed, then fails later when locating `bin/cargo`.

Check the primary executable instead, so incomplete toolchains follow the existing uninstall and reinstall path.

Validated with `cargo fmt -p rust_tool --check`.