### PR TITLE
feat(go): report project .go sources as project-graph inputs

### DIFF
--- a/toolchains/go/CHANGELOG.md
+++ b/toolchains/go/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+#### 🐞 Fixes
+
+- Relationship inference now reports each project's own `.go` sources as project-graph inputs. Edges are derived from `go list` reading imports, so a new import with no `go.mod` change previously left a locally cached graph stale until a config change or `moon clean`. The walk stops at nested project boundaries, so a project's sources exclude those owned by projects nested beneath it.
+
 ## 1.5.0
 
 #### 🚀 Updates

--- a/toolchains/go/src/package_graph.rs
+++ b/toolchains/go/src/package_graph.rs
@@ -305,7 +305,46 @@ impl GoPackageGraph {
             })
             .collect();
 
+        // Relationship inference reads a project's `.go` sources through
+        // `go list`, so an added import must invalidate the cached graph even
+        // when `go.mod` is untouched. Report those sources as graph inputs;
+        // without them a new edge only appears after a config change or
+        // `moon clean`. Only relevant when `go list` is what resolves edges.
+        if self.go_exists
+            && (self.config.infer_relationships || self.config.infer_relationships_from_tests)
+        {
+            let sources = self.gather_source_inputs();
+            self.input_files.extend(sources);
+        }
+
         Ok(())
+    }
+
+    // Every project's own `.go` files, for the graph cache to invalidate on.
+    // The walk stops at nested project roots — those files belong to the
+    // nested project, so this avoids re-walking them (and the whole workspace
+    // for a root-level project) under each ancestor.
+    fn gather_source_inputs(&self) -> Vec<VirtualPath> {
+        let mut files = vec![];
+
+        for project in &self.projects {
+            if project.import_path.is_none() {
+                continue;
+            }
+
+            let boundaries = self
+                .projects
+                .iter()
+                .filter(|other| other.id != project.id)
+                .map(|other| &other.root)
+                .collect::<Vec<_>>();
+
+            collect_go_files(&project.root, &boundaries, &mut files);
+        }
+
+        files.sort_by(|a, b| (**a).cmp(&**b));
+        files.dedup();
+        files
     }
 
     pub fn projects(&self) -> &[GoProject] {
@@ -440,6 +479,30 @@ impl GoPackageGraph {
         }
 
         Ok(dependencies)
+    }
+}
+
+// Recursively collect `.go` files under `dir`, without descending into any
+// `boundaries` directory (a nested project's root), whose files belong to
+// that project rather than this one.
+fn collect_go_files(dir: &VirtualPath, boundaries: &[&VirtualPath], out: &mut Vec<VirtualPath>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries {
+        let name = entry.file_name();
+        let path = dir.join(&name);
+
+        if entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
+            if boundaries.iter().any(|boundary| **boundary == path) {
+                continue;
+            }
+
+            collect_go_files(&path, boundaries, out);
+        } else if name.to_str().is_some_and(|name| name.ends_with(".go")) {
+            out.push(path);
+        }
     }
 }
 

--- a/toolchains/go/tests/tier2_test.rs
+++ b/toolchains/go/tests/tier2_test.rs
@@ -274,12 +274,18 @@ mod go_toolchain_tier2 {
                     ])
                 );
 
+                // `go.mod`s plus each project's own `.go` sources — inference
+                // reads sources via `go list`, so they invalidate the graph.
                 assert_eq!(
                     output.input_files,
                     [
                         VirtualPath::new("/workspace/a/go.mod"),
                         VirtualPath::new("/workspace/b/go.mod"),
                         VirtualPath::new("/workspace/c/go.mod"),
+                        VirtualPath::new("/workspace/a/lib.go"),
+                        VirtualPath::new("/workspace/a/pkg/pkg.go"),
+                        VirtualPath::new("/workspace/b/lib.go"),
+                        VirtualPath::new("/workspace/c/lib.go"),
                     ]
                 );
             }
@@ -366,7 +372,53 @@ mod go_toolchain_tier2 {
                     )])
                 );
 
-                assert_eq!(output.input_files, [VirtualPath::new("/workspace/go.mod")]);
+                // The shared root `go.mod`, plus every project's own sources.
+                // `apps/a/tool` isn't a project here, so its file belongs to
+                // `a`.
+                assert_eq!(
+                    output.input_files,
+                    [
+                        VirtualPath::new("/workspace/go.mod"),
+                        VirtualPath::new("/workspace/apps/a/main.go"),
+                        VirtualPath::new("/workspace/apps/a/tool/tool.go"),
+                        VirtualPath::new("/workspace/libs/b/lib.go"),
+                    ]
+                );
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn source_inputs_stop_at_nested_project_boundaries() {
+                let sandbox = create_moon_sandbox("projects-single-module");
+                let plugin = sandbox.create_toolchain("go").await;
+
+                let mut input = ExtendProjectGraphInput::default();
+                // The root, an app, the app's nested `tool` project, and a lib
+                // all share the one module.
+                input.project_sources.insert(Id::raw("root"), ".".into());
+                input.project_sources.insert(Id::raw("a"), "apps/a".into());
+                input
+                    .project_sources
+                    .insert(Id::raw("tool"), "apps/a/tool".into());
+                input.project_sources.insert(Id::raw("b"), "libs/b".into());
+                input.toolchain_config = json!({
+                    "inferRelationships": true
+                });
+
+                let output = plugin.extend_project_graph(input).await;
+
+                // `apps/a/tool/tool.go` is owned by `tool`, not `a`, and the
+                // root project owns none of the nested projects' files — so the
+                // walk stops at each project boundary and every source appears
+                // exactly once, none attributed to an ancestor.
+                assert_eq!(
+                    output.input_files,
+                    [
+                        VirtualPath::new("/workspace/go.mod"),
+                        VirtualPath::new("/workspace/apps/a/main.go"),
+                        VirtualPath::new("/workspace/apps/a/tool/tool.go"),
+                        VirtualPath::new("/workspace/libs/b/lib.go"),
+                    ]
+                );
             }
 
             #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Apologies, bit of a bug from my last PR that slipped by me. I didn't realise this was being cached based solely on the go.mod. This PR attempts to find all .go files that belong in that project and add these as inputs to the project-graph, as that's what we're basing the project inference on. 